### PR TITLE
Fix dependencies to use PixiJS packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,17 +31,21 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^17.0.21",
-    "@types/pixi.js": "^5.0.0",
     "fhead": "^3.2.7",
     "lil-gui": "^0.16.1",
+    "pixi.js": "^6.2.2",
     "prettier": "^2.5.1",
     "tsc-alias": "^1.6.3",
     "typescript": "^4.6.2",
     "vite": "^2.8.4",
     "vite-plugin-string": "^1.1.2"
   },
-  "dependencies": {
-    "pixi.js": "^6.2.2"
+  "peerDependencies": {
+    "@pixi/constants": "^6.2.2",
+    "@pixi/core": "^6.2.2",
+    "@pixi/filter-blur": "^6.2.2",
+    "@pixi/filter-color-matrix": "^6.2.2",
+    "@pixi/utils": "^6.2.2"
   },
   "fhead": {
     "comment": "/** Do not use this config in production! */",

--- a/src/filters/black/index.ts
+++ b/src/filters/black/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Black extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/bloom/index.ts
+++ b/src/filters/bloom/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Bloom extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/blur/index.ts
+++ b/src/filters/blur/index.ts
@@ -1,11 +1,11 @@
 import {
-  CLEAR_MODES,
   Filter,
-  filters,
   FilterState,
   FilterSystem,
   RenderTexture,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from '@pixi/constants';
+import { BlurFilter } from '@pixi/filter-blur';
 
 export class Blur extends Filter {
   private _blurFilter: any;
@@ -13,7 +13,7 @@ export class Blur extends Filter {
   constructor(value: number = 0) {
     super(null, null);
 
-    this._blurFilter = new filters.BlurFilter();
+    this._blurFilter = new BlurFilter();
     this.value = value;
   }
 

--- a/src/filters/brightness/index.ts
+++ b/src/filters/brightness/index.ts
@@ -2,10 +2,9 @@ import {
   Filter,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-  filters,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { ColorMatrixFilter } from "@pixi/filter-color-matrix";
 
 export class Brightness extends Filter {
@@ -13,7 +12,7 @@ export class Brightness extends Filter {
   constructor(value: number = 0) {
     super(null, null);
 
-    this._colorMatrixFilter = new filters.ColorMatrixFilter();
+    this._colorMatrixFilter = new ColorMatrixFilter();
     this.value = value;
   }
 

--- a/src/filters/clarity/index.ts
+++ b/src/filters/clarity/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Clarity extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/contrast/index.ts
+++ b/src/filters/contrast/index.ts
@@ -2,10 +2,9 @@ import {
   Filter,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-  filters,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { ColorMatrixFilter } from "@pixi/filter-color-matrix";
 
 export class Contrast extends Filter {
@@ -13,7 +12,7 @@ export class Contrast extends Filter {
   constructor(value: number = 0) {
     super(null, null);
 
-    this._colorMatrixFilter = new filters.ColorMatrixFilter();
+    this._colorMatrixFilter = new ColorMatrixFilter();
     this.value = value;
   }
 

--- a/src/filters/curves/index.ts
+++ b/src/filters/curves/index.ts
@@ -1,13 +1,11 @@
 //  @ts-nocheck
 import {
   Filter,
-  utils,
-  Texture,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { CanvasSQ } from "@/tools/CanvasSQ";
 import { interpolate } from "@/tools/interpolate";
 import { Mapping } from "@/filters/mapping";

--- a/src/filters/dehaze/index.ts
+++ b/src/filters/dehaze/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Dehaze extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/exposure/index.ts
+++ b/src/filters/exposure/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Exposure extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/fill/colorBurn/index.ts
+++ b/src/filters/fill/colorBurn/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class ColorBurn extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class ColorBurn extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/colorDodge/index.ts
+++ b/src/filters/fill/colorDodge/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class ColorDodge extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class ColorDodge extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/default/index.ts
+++ b/src/filters/fill/default/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class Default extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class Default extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/hardLight/index.ts
+++ b/src/filters/fill/hardLight/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class HardLight extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class HardLight extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/index.ts
+++ b/src/filters/fill/index.ts
@@ -1,11 +1,10 @@
 import {
-  CLEAR_MODES,
   Filter,
-  filters,
   FilterState,
   FilterSystem,
   RenderTexture,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { SoftLight } from "@/filters/fill/softLight";
 import { HardLight } from "@/filters/fill/hardLight";
 import { VividLight } from "@/filters/fill/vividLight";

--- a/src/filters/fill/multiply/index.ts
+++ b/src/filters/fill/multiply/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class Multiply extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class Multiply extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/overlay/index.ts
+++ b/src/filters/fill/overlay/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class Overlay extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class Overlay extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/screen/index.ts
+++ b/src/filters/fill/screen/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class Screen extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class Screen extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/softLight/index.ts
+++ b/src/filters/fill/softLight/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class SoftLight extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class SoftLight extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/fill/vividLight/index.ts
+++ b/src/filters/fill/vividLight/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture, utils } from "pixi.js";
+import { Filter } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class VividLight extends Filter {
   constructor(value: number = 0, fillColor: string = "#f20") {
@@ -11,7 +12,7 @@ export class VividLight extends Filter {
   }
 
   public update() {
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.fillColor));
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.fillColor));
     this.uniforms.color = [r, g, b, 1];
   }
 

--- a/src/filters/glamour/index.ts
+++ b/src/filters/glamour/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Glamour extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/grain/index.ts
+++ b/src/filters/grain/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Grain extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/highlights/index.ts
+++ b/src/filters/highlights/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Highlights extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/hue/index.ts
+++ b/src/filters/hue/index.ts
@@ -2,10 +2,9 @@ import {
   Filter,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-  filters,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { ColorMatrixFilter } from "@pixi/filter-color-matrix";
 
 export class Hue extends Filter {
@@ -13,7 +12,7 @@ export class Hue extends Filter {
   constructor(value: number = 0) {
     super(null, null);
 
-    this._colorMatrixFilter = new filters.ColorMatrixFilter();
+    this._colorMatrixFilter = new ColorMatrixFilter();
     this.value = value;
   }
 

--- a/src/filters/levels/index.ts
+++ b/src/filters/levels/index.ts
@@ -1,13 +1,12 @@
 //  @ts-nocheck
 import {
   Filter,
-  utils,
-  Texture,
   FilterSystem,
   RenderTexture,
   CLEAR_MODES,
   FilterState,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { Mapping } from "@/filters/mapping";
 import { LevelMapping } from "@/tools/level";
 

--- a/src/filters/mapping/index.ts
+++ b/src/filters/mapping/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, Texture } from "pixi.js";
+import { Filter, Texture } from "@pixi/core";
 
 export class Mapping extends Filter {
   constructor(paletteMap: ImageData) {

--- a/src/filters/preset/index.ts
+++ b/src/filters/preset/index.ts
@@ -2,9 +2,9 @@ import {
   Filter,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { filters } from "../index";
 import { PresetKey, presetConfig } from "./preset";
 import { Curves } from "@/filters/curves";

--- a/src/filters/saturation/index.ts
+++ b/src/filters/saturation/index.ts
@@ -2,10 +2,9 @@ import {
   Filter,
   FilterSystem,
   RenderTexture,
-  CLEAR_MODES,
   FilterState,
-  filters,
-} from "pixi.js";
+} from "@pixi/core";
+import { CLEAR_MODES } from "@pixi/constants";
 import { ColorMatrixFilter } from "@pixi/filter-color-matrix";
 
 export class Saturation extends Filter {
@@ -13,7 +12,7 @@ export class Saturation extends Filter {
   constructor(value: number = 0) {
     super(null, null);
 
-    this._colorMatrixFilter = new filters.ColorMatrixFilter();
+    this._colorMatrixFilter = new ColorMatrixFilter();
     this.value = value;
   }
 

--- a/src/filters/shadows/index.ts
+++ b/src/filters/shadows/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "../highlights/fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Shadows extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/sharpen/index.ts
+++ b/src/filters/sharpen/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Sharpen extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/smooth/index.ts
+++ b/src/filters/smooth/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Smooth extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/temperature/index.ts
+++ b/src/filters/temperature/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Temperature extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/tint/index.ts
+++ b/src/filters/tint/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Tint extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/toning/index.ts
+++ b/src/filters/toning/index.ts
@@ -1,6 +1,7 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter, utils, Texture } from "pixi.js";
+import { Filter, Texture } from "@pixi/core";
+import { hex2rgb, string2hex } from "@pixi/utils";
 
 export class Toning extends Filter {
   private _imageData: ImageData;
@@ -20,9 +21,9 @@ export class Toning extends Filter {
 
   public update() {
     //  https://github.com/pixijs/pixijs/issues/5484#issuecomment-470022698
-    const [r, g, b] = utils.hex2rgb(utils.string2hex(this.uniforms.lightColor));
-    const [rDark, gDark, bDark] = utils.hex2rgb(
-      utils.string2hex(this.uniforms.darkColor)
+    const [r, g, b] = hex2rgb(string2hex(this.uniforms.lightColor));
+    const [rDark, gDark, bDark] = hex2rgb(
+      string2hex(this.uniforms.darkColor)
     );
 
     let paletteMap = this._imageData;

--- a/src/filters/vibrance/index.ts
+++ b/src/filters/vibrance/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class Vibrance extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/vignetteBlack/index.ts
+++ b/src/filters/vignetteBlack/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class VignetteBlack extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/vignetteWhite/index.ts
+++ b/src/filters/vignetteWhite/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class VignetteWhite extends Filter {
   constructor(value: number = 0) {

--- a/src/filters/white/index.ts
+++ b/src/filters/white/index.ts
@@ -1,6 +1,6 @@
 //  @ts-ignore
 import fragment from "./fragment.frag";
-import { Filter } from "pixi.js";
+import { Filter } from "@pixi/core";
 
 export class White extends Filter {
   constructor(value: number = 0) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,14 @@
 import vitePluginString from "vite-plugin-string";
 import path from "path";
 
+const globals = {
+  "@pixi/constants": "PIXI",
+  "@pixi/core": "PIXI",
+  "@pixi/filter-color-matrix": "PIXI.filters",
+  "@pixi/filter-blur": "PIXI.filters",
+  "@pixi/utils": "PIXI.utils"
+};
+
 /**
  * @type {import('vite').UserConfig}
  */
@@ -14,7 +22,10 @@ const config = {
     },
     minify: true,
     rollupOptions: {
-      external: ["pixi.js"],
+      external: Object.keys(globals),
+      output: {
+        globals,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Fixes #3 

### Changed

* Converts the `pixi.js` dependency to use the `@pixi/*` packages instead
* Removes `@types/pixi.js` at this is not longer necessary

### Advantages

* Allows end-users to create the smallest possible footprint (e.g. https://pixijs.io/customize)
* Works with either `pixi.js` or `pixi.js-legacy` bundle
* Better conforms to PixiJS's filters repo: https://github.com/pixijs/filters